### PR TITLE
Resolve issue with replacing Secrets when using the `-u` switch

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -7,12 +7,17 @@ Supports both json and yaml based OpenShift configuration templates.
 ## Environment Setup
 
 1. Clone this repository to your local machine.
+1. Install [jq](https://stedolan.github.io/jq/).  [jq](https://stedolan.github.io/jq/) is used by some of the scripts to manipulate the configuration files in preparation for update/replace operations.  The recommended approach is to use either [Homebrew](https://brew.sh/) (MAC) or [Chocolatey](https://chocolatey.org/) (Windows) to install the required packages.
+      - Windows:
+        - `chocolatey install jq`
+      - MAC:
+        - `brew install jq`
 1. Update your path to include a reference to the `bin` directory
 
-Using GIT Bash on Windows as an example;
-1. Create a `.bashrc` file in your home directory (`C:\Users\<UserName/>`, for example `C:\Users\Wade`).
-1. Add the line `PATH=${PATH}:/c/openshift-project-tools/bin`
-1. Restart GIT Bash.  _If you have not done this before, GIT will write out some warnings and create some files for you that fix the issues._
+    Using GIT Bash on Windows as an example;
+    1. Create a `.bashrc` file in your home directory (`C:\Users\<UserName/>`, for example `C:\Users\Wade`).
+    1. Add the line `PATH=${PATH}:/c/openshift-project-tools/bin`
+    1. Restart GIT Bash.  _If you have not done this before, GIT will write out some warnings and create some files for you that fix the issues._
 
 All of the scripts will be available on the path and can be run from any directory.  This is important as many of the scripts expect to be run from the top level `./openshift` directory you will create in your project.
 

--- a/bin/ocFunctions.inc
+++ b/bin/ocFunctions.inc
@@ -551,6 +551,16 @@ runInContainer() {
   fi
 }
 
+isInstalled(){
+  rtnVal=$(type "$1" >/dev/null 2>&1)
+  rtnCd=$?
+  if [ ${rtnCd} -ne 0 ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 # =================================================================================================================
 # Database Managment Functions:
 # -----------------------------------------------------------------------------------------------------------------
@@ -666,7 +676,7 @@ deletePostgreSqlDatabase() {
   _databasePodName=${1}
   _dataDirectory=${2:-"/var/lib/pgsql/data/userdata"}
   if [ -z "${_databasePodName}" ]; then
-    echo -e \\n"dropAndRecreatePostgreSqlDatabase; Missing parameter!"\\n
+    echo -e \\n"deletePostgreSqlDatabase; Missing parameter!"\\n
     exit 1
   fi
 


### PR DESCRIPTION
- Resolve the issue where existing Secrets were replaced with new values when the `genDepls.sh` script is run with the `-u` (update) switch.
- When the `-u` switch is used the processed deployment configurations are run through [jq](https://stedolan.github.io/jq/) to strip out any Secret resources that may exist in the list.  This ensures existing Secrets remain untouched.  This is especially important when randomly Secrets are used to store randomly generated credentials for things such as a database.
- Add a dependency check for [jq](https://stedolan.github.io/jq/)
- Update documentation