### PR TITLE
Update listBuildRefs output formatting

### DIFF
--- a/bin/ocFunctions.inc
+++ b/bin/ocFunctions.inc
@@ -1599,6 +1599,6 @@ function listBuildRefs() {
   (
     projectName=${1:-${TOOLS}}
     echo
-    oc -n ${projectName} get bc --template '{{ range .items }}{{ printf "%s,%s,%s\n" .metadata.name .spec.source.git.uri .spec.source.git.ref}}{{end}}' | sed 's~%!s(<nil>)~~g' | column -t -s ,
+    oc -n ${projectName} get bc --template '{{ range .items }}{{ printf "%s,%s,%s\n" .metadata.name .spec.source.git.uri .spec.source.git.ref}}{{end}}' | sed 's~%!s(<nil>)~-~g' | column -t -s ,
   )
 }


### PR DESCRIPTION
- Use a '-' rather than blank space when builds don't have a git ref