### PR TITLE
Fix issues with using comma delimiters

### DIFF
--- a/bin/compDeployments.sh
+++ b/bin/compDeployments.sh
@@ -95,21 +95,21 @@ generateConfigs() {
     unset overrideScriptVars
 
     if [ -f "${PARAMFILE}" ]; then
-      overrideScriptVars=$(readConf -f ${PARAMFILE})
+      overrideScriptVars=$(readConf -f -d '\~' ${PARAMFILE})
       PARAMFILE="--param-file=${PARAMFILE}"
     else
       PARAMFILE=""
     fi
 
     if [ -f "${ENVPARAM}" ]; then
-      overrideScriptVars+=",$(readConf -f ${ENVPARAM})"
+      overrideScriptVars+=",$(readConf -f -d '\~' ${ENVPARAM})"
       ENVPARAM="--param-file=${ENVPARAM}"
     else
       ENVPARAM=""
     fi
 
     if [ -f "${LOCALPARAM}" ]; then
-      overrideScriptVars+=",$(readConf -f ${LOCALPARAM})"
+      overrideScriptVars+=",$(readConf -f -d '\~' ${LOCALPARAM})"
       LOCALPARAM="--param-file=${LOCALPARAM}"
     else
       LOCALPARAM=""
@@ -117,8 +117,8 @@ generateConfigs() {
 
     # Parameter overrides can be defined for individual deployment templates at the root openshift folder level ...
     if [ ! -z ${PARAM_OVERRIDE_SCRIPT} ] && [ -f ${PARAM_OVERRIDE_SCRIPT} ]; then
-      # Read the CSV key=value pairs into an array ...
-      IFS=',' read -ra overrideScriptVarsArray <<< "${overrideScriptVars}"
+      # Read the TSV key=value pairs into an array ...
+      IFS='~' read -ra overrideScriptVarsArray <<< "${overrideScriptVars}"
       echo -e "Loading parameter overrides for ${deploy} ..."
       SPECIALDEPLOYPARM+=" $(env "${overrideScriptVarsArray[@]}" ${PARAM_OVERRIDE_SCRIPT})"
     fi

--- a/bin/ocFunctions.inc
+++ b/bin/ocFunctions.inc
@@ -1063,15 +1063,25 @@ getPodNameByLabel() {
 readConf(){
   (
     local OPTIND
+    local OPTARG
     unset local flatten
-    while getopts f FLAG; do
+    unset local delimiter
+    while getopts fd: FLAG; do
       case $FLAG in
         f )
           local flatten=1
           ;;
+        d )
+          local delimiter=${OPTARG}
+          ;;
       esac
     done
     shift $((OPTIND-1))
+
+    # Comma delimit by default ... 
+    if [ -z ${delimiter} ]; then
+      delimiter=','
+    fi
 
     configFile=${1}
     if [ -f ${configFile} ]; then
@@ -1080,8 +1090,8 @@ readConf(){
       _value=$(sed '/^[[:blank:]]*#/d;s/#.*//' ${configFile})
 
       if [ ! -z ${flatten} ]; then
-        # flatten into a single line comma delimited line ...
-        filters=':a;N;$!ba;s~\n~,~g;'
+        # flatten into a single line delimited string ...
+        filters=":a;N;\$!ba;s~\n~${delimiter}~g;"
         _value=$(echo "${_value}" | sed "${filters}")
       fi
     fi


### PR DESCRIPTION
- Add support for defining the delimiter when calling `readConf`.
- Use '~' delimiting in compDeployments.sh to support `.param` values containing commas.