### PR TITLE
Add support for reading a parameter from the override param file

### DIFF
--- a/bin/overrides.inc
+++ b/bin/overrides.inc
@@ -93,6 +93,14 @@ writeParameter(){
   )
 }
 
+getParameter(){
+  (
+    _paramName=${1}
+    # Reads a parameter from the override param file.
+    echo $(grep ${_paramName} $"${_overrideParamFile}" | awk -F= '{print $2}')
+  )
+}
+
 generateKey(){
   (
     _length=${1:-48}


### PR DESCRIPTION
- Supports reading parameter back from the  override param file during `override` script execution.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>