### PR TITLE
Add support for defining "global" network security policies

### DIFF
--- a/bin/ocFunctions.inc
+++ b/bin/ocFunctions.inc
@@ -422,17 +422,73 @@ getTemplates () {
   )
 }
 
-getBuildTemplates () {
+nspTemplateFilter="\bNetworkSecurityPolicy\b\|\bExternalNetwork\b\|\bNetworkPolicy\b"
+getNspTemplates () {
   (
+    _filter=${1}
+    shift
     _searchPaths=${@}
-    echo $(getTemplates "\bBuildConfig\b\|\bpullSecret\b\|\bImageStream\b\|kind:.ImageStream$" ${_searchPaths})
+    nspTemplates=$(getTemplates "${nspTemplateFilter}" ${_searchPaths})
+    buildAndDeployTemplates+=" $(getTemplates "${buildTemplateFilter}" ${_searchPaths})"
+    buildAndDeployTemplates+=" $(getTemplates "${deploymentTemplateFilter}" ${_searchPaths})"
+    echo $(filterList "${nspTemplates}" "${buildAndDeployTemplates}") | tr " " "\n" | grep ${_filter}
   )
 }
 
+filterList () {
+  (
+    listItems=${1}
+    filterItems=${2}
+
+    OIFS=$IFS
+    IFS=" "
+
+    unset filteredList
+    filterItemsArray=(${filterItems})
+    for listItem in ${listItems}; do
+      if ! contains "${listItem}" "${filterItemsArray[@]}"; then
+        filteredList+=" ${listItem}"
+      fi
+    done
+
+    IFS=$OIFS
+    echo ${filteredList}
+  )
+}
+
+getBuildNspTemplates () {
+  (
+    _searchPaths=${@}
+    echo $(getNspTemplates "build.*" ${_searchPaths})
+  )
+}
+
+getDeploymentNspTemplates () {
+  (
+    _searchPaths=${@}
+    echo $(getNspTemplates "deploy.*" ${_searchPaths})
+  )
+}
+
+buildTemplateFilter="\bBuildConfig\b\|\bpullSecret\b\|\bImageStream\b\|kind:.ImageStream$"
+getBuildTemplates () {
+  (
+    _searchPaths=${@}
+    unset buildTemplates
+    buildTemplates+=" $(getTemplates "${buildTemplateFilter}" ${_searchPaths})"
+    buildTemplates+=" $(getBuildNspTemplates ${_searchPaths})"
+    echo ${buildTemplates}
+  )
+}
+
+deploymentTemplateFilter="\bDeploymentConfig\b\|\bStatefulSet\b\|\bRoute\b\|\bSecret\b"
 getDeploymentTemplates () {
   (
     _searchPaths=${@}
-    echo $(getTemplates "\bDeploymentConfig\b\|\bStatefulSet\b\|\bRoute\b\|\bSecret\b" ${_searchPaths})
+    unset deploymentTemplates
+    deploymentTemplates+=" $(getTemplates "${deploymentTemplateFilter}" ${_searchPaths})"
+    deploymentTemplates+=" $(getDeploymentNspTemplates ${_searchPaths})"
+    echo ${deploymentTemplates}
   )
 }
 

--- a/bin/settings.sh
+++ b/bin/settings.sh
@@ -145,9 +145,22 @@ listProfileDetails() {
       . ${PWD}/${settingsFile}
       
       # List the templates for the profile ...
-      templates=$(getConfigTemplates $(getTemplateDir) 2>/dev/null) 
+      templates=$(getBuildTemplates $(getTemplateDir) 2>/dev/null)
+      echo -e "  Build Templates:"
       for template in ${templates}; do
-        echo "  - ${template}"
+        echo "    - ${template}"
+      done
+
+      templates=$(getDeploymentTemplates $(getTemplateDir) 2>/dev/null)
+      echo -e "\n  Deployment Templates:"
+      for template in ${templates}; do
+        echo "    - ${template}"
+      done
+
+      templates=$(getConfigTemplates $(getTemplateDir) 2>/dev/null)
+      echo -e "\n  Configuration Templates:"
+      for template in ${templates}; do
+        echo "    - ${template}"
       done
     fi
   done


### PR DESCRIPTION
- Add support for defining "global" network security policies separate from the application service configurations.
- Support separation of "global" NSPs for build and configuration environment via file naming convention; `build.*` and `deploy.*`
- Ensure the standalone NSPs are processes just like other build and deployment configuration files; parameter generation, processing, publishing, etc.
- Update global `profileDetails` command to output additional configuration details.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>