### PR TITLE
Mac timeout fix

### DIFF
--- a/bin/testConnection
+++ b/bin/testConnection
@@ -71,7 +71,6 @@ fi
 # Bash on MacOS does not have the timeout function. We'll check the OS and, if it's MacOS (Darwin) based, we will
 # create a timeout function using Perl. Perl function from this gist https://gist.github.com/jaytaylor/6527607.
 OS=$(uname | tr '[:upper:]' '[:lower:]')
-echo $OS
 if [[ "$OS" == "darwin"* ]]; then
   function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
 fi

--- a/bin/testConnection
+++ b/bin/testConnection
@@ -67,6 +67,15 @@ else
   echo -e "${_yellow}Please ensure the openshift-developer-tools are installed on and registered on your path.${_nc}"
   echo -e "${_yellow}https://github.com/BCDevOps/openshift-developer-tools${_nc}"
 fi
+
+# Bash on MacOS does not have the timeout function. We'll check the OS and, if it's MacOS (Darwin) based, we will
+# create a timeout function using Perl. Perl function from this gist https://gist.github.com/jaytaylor/6527607.
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+echo $OS
+if [[ "$OS" == "darwin"* ]]; then
+  function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+fi
+
 # =================================================================================================================
 
 # =================================================================================================================


### PR DESCRIPTION
If the detected os is darwin, create a timeout function using Perl to allow MacOS to run the testConnection script.